### PR TITLE
Fix: Add missing command to snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,6 +19,7 @@ environment:
 
 apps:
   ocrmypdfgui:
+    command: python3 -m ocrmypdfgui
     desktop: $SNAPCRAFT_PROJECT_DIR/gui/ocrmypdfgui.desktop
     extensions: [gnome-3-38]
 


### PR DESCRIPTION
The Snapcraft build was failing due to a missing 'command' property in the 'apps/ocrmypdfgui' section of the snapcraft.yaml file.

This commit adds the required 'command: python3 -m ocrmypdfgui' to specify the entry point for the application.