### PR TITLE
Refactor snapcraft.yaml and fix GUI bugs

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: ocrmypdfgui # you probably want to 'snapcraft register <name>'
 title: ocrmypdfgui
 base: core20 # the base snap is the execution environment for this snap
-version: '0.9.08' # just for humans, typically '1.2+git' or '1.3.2'
+version: '0.9.15' # just for humans, typically '1.2+git' or '1.3.2'
 summary: Hobby Project GUI for the Python Program "OCRmyPDF" by James R. Barlow
 description: |
   I use James R. Barlow's OCRmyPDF heavily in my paperless Office and have created this Python Project as a GUI wrapper to run batch jobs on my filesystem. This is strictly a Hobby Project and is not "official". Feel free to use it if you like. Includes full current version of OCRmyPDF as backend. Icons and banner made by Freepik from www.flaticon.com
@@ -36,24 +36,29 @@ parts:
   ocrmypdfgui:
     # See 'snapcraft plugins'
     plugin: python
-    source: 
+    source: .
 
     python-packages:
-      - cffi  # must be a setup and install requirement
-      - pdfminer.six
-      - pikepdf
-      - Pillow
-      - pluggy
-      - reportlab
+      - cffi # >= 1.9.1
+      - coloredlogs # >= 14.0
+      - img2pdf # >= 0.3.0, < 0.5
+      - ocrmypdf # >= 12.0.2
+      - pdfminer.six # >= 20191110, != 20200720, <= 20201018
+      - pikepdf # >= 2.10.0
+      - Pillow # >= 8.1.2
+      - pluggy # >= 0.13.0, < 1.0
+      - PyGObject
+      - pytesseract # >= 0.3.8
+      - rarfile # >= 3.0
+      - reportlab # >= 3.5.66
       - setuptools
-      - tqdm
-      - pipe
+      - tqdm # >= 4
+
+    stage-packages:
+      - ghostscript
+      - tesseract-ocr-eng
 
     override-build: |
       ln -sf ../usr/lib/libsnapcraft-preload.so $SNAPCRAFT_PART_INSTALL/lib/libsnapcraft-preload.so
-      rm -rf $SNAPCRAFT_PART_INSTALL/usr/lib/python3.9/distutils
-      cp -r /usr/lib/python3.9/distutils $SNAPCRAFT_PART_INSTALL/usr/lib/python3.9/distutils
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/include/
-      cp -r /usr/include/python3.9 $SNAPCRAFT_PART_INSTALL/usr/include/python3.9
       snapcraftctl build
 


### PR DESCRIPTION
This commit addresses several issues in the ocrmypdfgui application and its Snapcraft packaging:

Key changes:

1.  **`snapcraft.yaml` Overhaul:**
    *   **Versioning:** Changed static version '0.9.08' to '0.9.15' to match `setup.py`.
    *   **Python Dependencies:** Synchronized `python-packages` with `setup.py`, adding `coloredlogs`, `img2pdf`, `ocrmypdf`, `pytesseract`, `PyGObject`, `rarfile` and removing an incorrect `pipe` entry.
    *   **Staged Libraries:** Added `ghostscript` and `tesseract-ocr-eng` to `stage-packages` to ensure these non-Python dependencies are bundled.
    *   **Build Process:** Removed hardcoded Python 3.9 paths from `override-build` script, making it compatible with `core20` (Python 3.8).
    *   **Source Path:** Ensured `source: .` is set for the main part.
    *   **Core Configuration:** Confirmed `base: core20` and `confinement: strict` are appropriate.

2.  **GUI Fixes (`src/ocrmypdfgui/gui.py`):**
    *   **Settings Loading:** Corrected the logic in `load_settings` to properly load existing settings, merge them with defaults, and handle file/format errors.
    *   **Icon Path:** Made the About dialog icon path snap-aware by using `$SNAP/gui/ocrmypdfgui.png` and providing a fallback for development.
    *   **Code Cleanup:** Removed commented-out/redundant code.

**Build Status:**
I planned to build and test the snap. However, I was unable to install `snapcraft` (neither via `apt` nor `snap install snapcraft`), preventing the build (`snapcraft` command) and subsequent testing steps. All planned modifications to the `snapcraft.yaml` and Python source code prior to the build step have been completed. The resulting `snapcraft.yaml` is structured to be buildable in an environment where `snapcraft` is available.

Further steps would involve running `snapcraft` to build the snap, testing its installation and functionality, and iteratively debugging any issues that arise during that process.