### PR TITLE
Further refine snapcraft Python tooling dependencies

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
   ocrmypdfgui:
     plugin: python
     source: .
-    build-packages:
+    build-packages: # Ensures these are present for venv creation by the plugin
       - python3-setuptools
       - python3-pip
       - python3-wheel
@@ -47,13 +47,12 @@ parts:
       - pikepdf
       - Pillow
       - pluggy
-      # PyGObject is removed from here - it will be provided by the gnome-3-38 extension
       - pytesseract
       - rarfile
       - reportlab
-      - setuptools
+      # setuptools # Removed - venv should provide its own
       - tqdm
-      - wheel
+      # wheel      # Removed - venv should provide its own
     stage-packages:
       - ghostscript
       - tesseract-ocr-eng # For English. Use tesseract-ocr-all for all languages (larger snap)


### PR DESCRIPTION
This commit updates snapcraft.yaml to prevent conflicts with SDK-provided Python tooling during the build.

Changes to snapcraft.yaml:
- Removed `setuptools` and `wheel` from the `python-packages` list in the `ocrmypdfgui` part.
- These packages are already specified in `build-packages` for the Python plugin to use when creating the virtual environment. The venv itself will then contain appropriate versions of these tools.
- This change aims to prevent errors where pip tries to uninstall tooling from the read-only SDK filesystem.