### PR TITLE
Okay, I've updated the snap app command to use an explicit usr/bin path.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,7 +19,7 @@ environment:
 
 apps:
   ocrmypdfgui:
-    command: ocrmypdfgui # Changed from 'python3 -m ocrmypdfgui'
+    command: usr/bin/ocrmypdfgui # Changed to usr/bin/ocrmypdfgui
     desktop: gui/ocrmypdfgui.desktop
     extensions: [gnome-3-38] # This provides PyGObject and other GTK dependencies
     plugs:


### PR DESCRIPTION
This commit modifies the `command` for the `ocrmypdfgui` app in `snapcraft.yaml` to use an explicit path.

Here's what I did:
- I changed `apps.ocrmypdfgui.command` from `ocrmypdfgui` to `usr/bin/ocrmypdfgui`.
- This attempts to resolve the "command does not exist" error by assuming the console script `ocrmypdfgui` is staged to `$SNAPCRAFT_PRIME/usr/bin/` by the Python plugin.