### PR TITLE
Manually stage script, desktop file, and icon

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,28 +1,27 @@
-name: ocrmypdfgui # you probably want to 'snapcraft register <name>'
+name: ocrmypdfgui
 title: ocrmypdfgui
-base: core20 # the base snap is the execution environment for this snap
-version: '0.9.08' # just for humans, typically '1.2+git' or '1.3.2'
+base: core20
+version: '0.9.15' # Matched with setup.py
 summary: Hobby Project GUI for the Python Program "OCRmyPDF" by James R. Barlow
 description: |
   I use James R. Barlow's OCRmyPDF heavily in my paperless Office and have created this Python Project as a GUI wrapper to run batch jobs on my filesystem. This is strictly a Hobby Project and is not "official". Feel free to use it if you like. Includes full current version of OCRmyPDF as backend. Icons and banner made by Freepik from www.flaticon.com
-icon: gui/ocrmypdfgui.png
-grade: stable # must be 'stable' to release into candidate/stable channels
-confinement: strict # use 'strict' once you have the right plugs and slots
-#
+icon: gui/ocrmypdfgui.png # Expects prime/gui/ocrmypdfgui.png
+grade: stable
+confinement: strict
+
 architectures: [amd64]
 
 environment:
-    TESSDATA_PREFIX: $SNAP/usr/share/tesseract-ocr/4.00/tessdata
-    GS_LIB: $SNAP/usr/share/ghostscript/9.50/Resource/Init
-    GS_FONTPATH: $SNAP/usr/share/ghostscript/9.50/Resource/Font
+    TESSDATA_PREFIX: $SNAP/usr/share/tesseract-ocr/4.00/tessdata # Verify version from staged tesseract
+    GS_LIB: $SNAP/usr/share/ghostscript/9.50/Resource/Init     # Verify version from staged ghostscript
+    GS_FONTPATH: $SNAP/usr/share/ghostscript/9.50/Resource/Font # Verify version from staged ghostscript
     LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu
 
 apps:
   ocrmypdfgui:
-    command: python3 -m ocrmypdfgui
-    desktop: $SNAPCRAFT_PROJECT_DIR/gui/ocrmypdfgui.desktop
-    extensions: [gnome-3-38]
-
+    command: usr/bin/ocrmypdfgui # Should be placed here by the modified override-build + prime
+    desktop: gui/ocrmypdfgui.desktop # Expects prime/gui/ocrmypdfgui.desktop
+    extensions: [gnome-3-38] 
     plugs:
       - desktop
       - desktop-legacy
@@ -31,29 +30,82 @@ apps:
       - home
       - removable-media
 
-
 parts:
   ocrmypdfgui:
-    # See 'snapcraft plugins'
     plugin: python
-    source: 
-
+    source: . # This includes the 'gui' directory
+    build-packages: 
+      - python3-setuptools
+      - python3-pip
+      - python3-wheel
     python-packages:
-      - cffi  # must be a setup and install requirement
+      - cffi
+      - coloredlogs
+      - img2pdf
+      - ocrmypdf
       - pdfminer.six
       - pikepdf
       - Pillow
       - pluggy
+      - pytesseract
+      - rarfile
       - reportlab
-      - setuptools
       - tqdm
-      - pipe
-
+    stage-packages:
+      - ghostscript
+      - tesseract-ocr-eng 
     override-build: |
-      ln -sf ../usr/lib/libsnapcraft-preload.so $SNAPCRAFT_PART_INSTALL/lib/libsnapcraft-preload.so
-      rm -rf $SNAPCRAFT_PART_INSTALL/usr/lib/python3.9/distutils
-      cp -r /usr/lib/python3.9/distutils $SNAPCRAFT_PART_INSTALL/usr/lib/python3.9/distutils
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/include/
-      cp -r /usr/include/python3.9 $SNAPCRAFT_PART_INSTALL/usr/include/python3.9
-      snapcraftctl build
+      set -x
+      echo "## Starting override-build for ocrmypdfgui part ##"
+      snapcraftctl build # This creates venv, installs packages, and runs pip install .
+      
+      echo "--- Manually staging ocrmypdfgui script within the part's install directory ---"
+      SCRIPT_IN_VENV="$SNAPCRAFT_PART_INSTALL/bin/ocrmypdfgui"
+      DEST_BIN_IN_PART_INSTALL="$SNAPCRAFT_PART_INSTALL/usr/bin" 
+      
+      if [ -f "$SCRIPT_IN_VENV" ]; then
+        echo "Found script at $SCRIPT_IN_VENV"
+        mkdir -p "$DEST_BIN_IN_PART_INSTALL"
+        echo "Copying $SCRIPT_IN_VENV to $DEST_BIN_IN_PART_INSTALL/ocrmypdfgui"
+        cp "$SCRIPT_IN_VENV" "$DEST_BIN_IN_PART_INSTALL/ocrmypdfgui"
+        chmod +x "$DEST_BIN_IN_PART_INSTALL/ocrmypdfgui"
+        echo "Copied ocrmypdfgui to $DEST_BIN_IN_PART_INSTALL/ocrmypdfgui and made executable."
+      else
+        echo "ERROR during override-build: ocrmypdfgui script NOT found at $SCRIPT_IN_VENV after 'snapcraftctl build'."
+        ls -la "$SNAPCRAFT_PART_INSTALL/bin/" || true 
+      fi
+      echo "## End of override-build for ocrmypdfgui part ##"
+    override-prime: |
+      set -x 
+      # Run default prime actions for this part.
+      snapcraftctl prime
+      
+      echo "--- Manually staging .desktop file and icon for priming ---"
+      # Source directory for these assets within the part's source directory
+      ASSETS_SOURCE_DIR="$SNAPCRAFT_PART_DIR/gui"
+      
+      # Destination directory in $SNAPCRAFT_PRIME where snapcraft expects to find them
+      # for the `desktop:` and `icon:` keys (e.g., gui/file.desktop)
+      DEST_GUI_DIR_IN_PRIME="$SNAPCRAFT_PRIME/gui"
+      
+      mkdir -p "$DEST_GUI_DIR_IN_PRIME"
+      
+      if [ -f "$ASSETS_SOURCE_DIR/ocrmypdfgui.desktop" ]; then
+        cp "$ASSETS_SOURCE_DIR/ocrmypdfgui.desktop" "$DEST_GUI_DIR_IN_PRIME/"
+        echo "Copied ocrmypdfgui.desktop to $DEST_GUI_DIR_IN_PRIME/"
+      else
+        echo "ERROR from override-prime: $ASSETS_SOURCE_DIR/ocrmypdfgui.desktop not found."
+      fi
+      
+      if [ -f "$ASSETS_SOURCE_DIR/ocrmypdfgui.png" ]; then
+        cp "$ASSETS_SOURCE_DIR/ocrmypdfgui.png" "$DEST_GUI_DIR_IN_PRIME/"
+        echo "Copied ocrmypdfgui.png to $DEST_GUI_DIR_IN_PRIME/"
+      else
+        echo "ERROR from override-prime: $ASSETS_SOURCE_DIR/ocrmypdfgui.png not found."
+      fi
 
+      echo "--- Listing $DEST_GUI_DIR_IN_PRIME (for .desktop and .icon) ---"
+      ls -la "$DEST_GUI_DIR_IN_PRIME" || true
+      echo "--- Listing $SNAPCRAFT_PRIME/usr/bin (for command) ---"
+      ls -la $SNAPCRAFT_PRIME/usr/bin || true
+      echo "--- End of override-prime for ocrmypdfgui part ---"


### PR DESCRIPTION
This commit updates snapcraft.yaml to:
1.  Use `override-build` to manually copy the `ocrmypdfgui` console script from the part's venv (`$SNAPCRAFT_PART_INSTALL/bin`) into `$SNAPCRAFT_PART_INSTALL/usr/bin/`. This ensures it's in a standard location within the part's artifacts.
2.  Use `override-prime` to manually copy the `ocrmypdfgui.desktop` and `ocrmypdfgui.png` files from the part's source directory (`$SNAPCRAFT_PART_DIR/gui`) into `$SNAPCRAFT_PRIME/gui/`. Snapcraft expects these files to be present in `prime` at paths relative to the prime directory for the `desktop` and `icon` keywords.

This comprehensive manual staging is an attempt to resolve previous "command not found" and "desktop file does not exist" errors by ensuring all necessary application assets are correctly placed for the final snap packaging process.