### PR TITLE
Fix: Simplify python-packages in snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,19 +41,7 @@ parts:
       - python3-wheel
       - findutils # Added for the find command in override-build
 
-    python-packages:
-      - cffi
-      - coloredlogs
-      - img2pdf
-      - ocrmypdf
-      - pdfminer.six
-      - pikepdf
-      - Pillow
-      - pluggy
-      - pytesseract
-      - rarfile
-      - reportlab
-      - tqdm
+    python-packages: []
     stage-packages:
       - ghostscript
       - tesseract-ocr-eng 


### PR DESCRIPTION
This change removes redundant package definitions from `parts.ocrmypdfgui.python-packages` in `snapcraft.yaml`.

These packages are already specified in `setup.py`'s `install_requires`. Removing them aims to:
1. Avoid version conflicts and multiple installations of the same packages during the snap build process.
2. Ensure that `pip install .` correctly generates and places the `ocrmypdfgui` executable in the virtual environment's `bin` directory as per `setup.py`'s `entry_points`.

The existing `override-build` script is expected to then find this executable and copy it to the correct location for the snap package, resolving the 'command not found' error during priming.