### PR TITLE
Feat: Migrate to core24 and update GNOME extension

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: ocrmypdfgui
 title: ocrmypdfgui
-base: core20
+base: core24
 version: '0.9.15' # Matched with setup.py
 summary: Hobby Project GUI for the Python Program "OCRmyPDF" by James R. Barlow
 description: |
@@ -21,7 +21,7 @@ apps:
   ocrmypdfgui:
     command: usr/bin/ocrmypdfgui 
     desktop: gui/ocrmypdfgui.desktop # Expects prime/gui/ocrmypdfgui.desktop
-    extensions: [gnome-3-38] 
+    extensions: [gnome] 
     plugs:
       - desktop
       - desktop-legacy
@@ -49,6 +49,14 @@ parts:
       set -x
       echo "## Starting override-build for ocrmypdfgui part ##"
       snapcraftctl build
+      echo "--- Upgrading pip, setuptools, wheel in venv ---"
+      $SNAPCRAFT_PART_INSTALL/bin/python -m pip install -U pip setuptools wheel
+      echo "--- Explicitly running pip install -v . ---"
+      $SNAPCRAFT_PART_INSTALL/bin/python -m pip install -v .
+      echo "--- Listing content of $SNAPCRAFT_PART_INSTALL (recursively) ---"
+      ls -Rla $SNAPCRAFT_PART_INSTALL/
+      echo "--- Listing content of $SNAPCRAFT_PART_INSTALL/bin/ (specifically) ---"
+      ls -la $SNAPCRAFT_PART_INSTALL/bin/
       
       echo "--- Locating ocrmypdfgui script within $SNAPCRAFT_PART_INSTALL ---"
       SCRIPT_IN_VENV_BIN="$SNAPCRAFT_PART_INSTALL/bin/ocrmypdfgui"


### PR DESCRIPTION
- Changed snap base from core20 to core24.
- Updated GNOME extension from gnome-3-38 to gnome.
- Kept existing diagnostic commands in override-build to continue debugging the executable script installation.