### PR TITLE
Fix: Correct Python interpreter path for snap in WSL

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -85,7 +85,8 @@ parts:
         mkdir -p "$DEST_BIN_IN_PART_INSTALL"
         cp "$FOUND_SCRIPT_PATH" "$DEST_BIN_IN_PART_INSTALL/ocrmypdfgui"
         chmod +x "$DEST_BIN_IN_PART_INSTALL/ocrmypdfgui"
-        echo "Copied $FOUND_SCRIPT_PATH to $DEST_BIN_IN_PART_INSTALL/ocrmypdfgui."
+        sed -i '1s|^#!.*python.*$|#!/usr/bin/env python3|' "$DEST_BIN_IN_PART_INSTALL/ocrmypdfgui"
+        echo "Copied $FOUND_SCRIPT_PATH to $DEST_BIN_IN_PART_INSTALL/ocrmypdfgui and updated shebang."
       else
         echo "WARNING: No ocrmypdfgui script found to stage into part's /usr/bin."
       fi


### PR DESCRIPTION
The ocrmypdfgui script within the snap had an incorrect shebang pointing to a build-time absolute path for the Python interpreter. This caused a "bad interpreter: Permission denied" error when running the snap, particularly in environments like WSL.

This commit modifies the `snapcraft.yaml` to explicitly change the shebang of the packaged `ocrmypdfgui` script to `#!/usr/bin/env python3`. This ensures that the correct Python interpreter available within the snap's runtime environment is used.

This change aims to resolve the primary execution error. Further testing will be needed to confirm if related shared library issues are also mitigated.